### PR TITLE
add copies of auspice export config json files with 'data_provenance' set to name=GISAID

### DIFF
--- a/configs/auspice_config_gisaid-broad.json
+++ b/configs/auspice_config_gisaid-broad.json
@@ -1,0 +1,157 @@
+{
+  "title": "SARS-CoV-2 Viral Genomes",
+  "maintainers": [
+    {"name": "Broad Institute Viral Genomics", "url": "https://www.broadinstitute.org/"}
+  ],
+  "colorings": [
+    {
+      "key": "location",
+      "title": "Location",
+      "type": "categorical"
+    },
+    {
+      "key": "division",
+      "title": "Admin Division",
+      "type": "categorical"
+    },
+    {
+      "key": "country",
+      "title": "Country",
+      "type": "categorical"
+    },
+    {
+      "key": "region",
+      "title": "Region",
+      "type": "categorical"
+    },
+    {
+      "key": "host",
+      "title": "Host",
+      "type": "categorical"
+    },
+    {
+      "key": "age",
+      "title": "Age",
+      "type": "continuous"
+    },
+    {
+      "key": "sex",
+      "title": "Sex",
+      "type": "categorical"
+    },
+    {
+      "key": "author",
+      "title": "Authors",
+      "type": "categorical"
+    },
+    {
+      "key": "originating_lab",
+      "title": "Originating Lab",
+      "type": "categorical"
+    },
+    {
+      "key": "submitting_lab",
+      "title": "Submitting Lab",
+      "type": "categorical"
+    },
+    {
+      "key": "recency",
+      "title": "Submission Date",
+      "type": "categorical"
+    },
+    {
+      "key": "gisaid_epi_isl",
+      "type": "categorical"
+    },
+    {
+      "key": "genbank_accession",
+      "type": "categorical"
+    },
+    {
+      "key": "country_exposure",
+      "title": "Country of exposure",
+      "type": "categorical"
+    },
+    {
+      "key": "division_exposure",
+      "title": "Division of exposure",
+      "type": "categorical"
+    },
+    {
+      "key": "region_exposure",
+      "title": "Region of exposure",
+      "type": "categorical"
+    },
+    {
+      "key": "pango_lineage",
+      "title": "Pangolin lineage",
+      "type": "categorical"
+    },
+    {
+      "key": "Nextstrain_clade",
+      "title": "Nextstrain Clade",
+      "type": "categorical"
+    },
+    {
+      "key": "GISAID_clade",
+      "title": "GISAID Clade",
+      "type": "categorical"
+    },
+    {
+      "key": "purpose_of_sequencing",
+      "title": "Purpose of Sequencing",
+      "type": "categorical"
+    },
+    {
+      "key": "geoloc_neusa",
+      "title": "Geoloc: NE USA",
+      "type": "categorical"
+    },
+    {
+      "key": "Northeast_USA_originating_lab",
+      "title": "NE USA Originating Lab",
+      "type": "categorical"
+    },
+     {
+      "key": "Northeast_USA_submitting_lab",
+      "title": "NE USA Submitting Lab",
+      "type": "categorical"
+    }
+  ],
+  "display_defaults": {
+    "color_by": "division",
+    "distance_measure": "num_date",
+    "geo_resolution": "division",
+    "map_triplicate": true,
+    "branch_label": "clade"
+  },
+  "geo_resolutions": [
+    "region",
+    "country",
+    "division",
+    "location"
+  ],
+  "panels": [
+    "tree",
+    "map",
+    "entropy",
+    "frequencies"
+  ],
+  "filters": [
+    "recency",
+    "region",
+    "country",
+    "division",
+    "purpose_of_sequencing",
+    "pango_lineage",
+    "Nextstrain_clade",
+    "GISAID_clade",
+    "originating_lab",
+    "submitting_lab"
+  ],
+  "data_provenance": [
+    {
+      "name": "GISAID"
+    }
+  ]
+}

--- a/configs/auspice_config_gisaid-broad_longitudinal.json
+++ b/configs/auspice_config_gisaid-broad_longitudinal.json
@@ -1,0 +1,163 @@
+{
+  "title": "SARS-CoV-2 Viral Genomes",
+  "maintainers": [
+    {"name": "Broad Institute Viral Genomics", "url": "https://www.broadinstitute.org/"}
+  ],
+  "colorings": [
+    {
+      "key": "location",
+      "title": "Location",
+      "type": "categorical"
+    },
+    {
+      "key": "division",
+      "title": "Admin Division",
+      "type": "categorical"
+    },
+    {
+      "key": "country",
+      "title": "Country",
+      "type": "categorical"
+    },
+    {
+      "key": "region",
+      "title": "Region",
+      "type": "categorical"
+    },
+    {
+      "key": "host",
+      "title": "Host",
+      "type": "categorical"
+    },
+    {
+      "key": "age",
+      "title": "Age",
+      "type": "continuous"
+    },
+    {
+      "key": "sex",
+      "title": "Sex",
+      "type": "categorical"
+    },
+    {
+      "key": "author",
+      "title": "Authors",
+      "type": "categorical"
+    },
+    {
+      "key": "originating_lab",
+      "title": "Originating Lab",
+      "type": "categorical"
+    },
+    {
+      "key": "submitting_lab",
+      "title": "Submitting Lab",
+      "type": "categorical"
+    },
+    {
+      "key": "recency",
+      "title": "Submission Date",
+      "type": "categorical"
+    },
+    {
+      "key": "gisaid_epi_isl",
+      "type": "categorical"
+    },
+    {
+      "key": "genbank_accession",
+      "type": "categorical"
+    },
+    {
+      "key": "country_exposure",
+      "title": "Country of exposure",
+      "type": "categorical"
+    },
+    {
+      "key": "division_exposure",
+      "title": "Division of exposure",
+      "type": "categorical"
+    },
+    {
+      "key": "region_exposure",
+      "title": "Region of exposure",
+      "type": "categorical"
+    },
+    {
+      "key": "pango_lineage",
+      "title": "Pangolin lineage",
+      "type": "categorical"
+    },
+    {
+      "key": "Nextstrain_clade",
+      "title": "Nextstrain Clade",
+      "type": "categorical"
+    },
+    {
+      "key": "GISAID_clade",
+      "title": "GISAID Clade",
+      "type": "categorical"
+    },
+    {
+      "key": "purpose_of_sequencing",
+      "title": "Purpose of Sequencing",
+      "type": "categorical"
+    },
+    {
+      "key": "geoloc_neusa",
+      "title": "Geoloc: NE USA",
+      "type": "categorical"
+    },
+    {
+      "key": "Northeast_USA_originating_lab",
+      "title": "NE USA Originating Lab",
+      "type": "categorical"
+    },
+     {
+      "key": "Northeast_USA_submitting_lab",
+      "title": "NE USA Submitting Lab",
+      "type": "categorical"
+    },
+       {
+      "key": "Longitudinal_Patient",
+      "title": "Longitudinal Patient",
+      "type": "categorical"
+    }
+  ],
+  "display_defaults": {
+    "color_by": "division",
+    "distance_measure": "num_date",
+    "geo_resolution": "division",
+    "map_triplicate": true,
+    "branch_label": "clade"
+  },
+  "geo_resolutions": [
+    "region",
+    "country",
+    "division",
+    "location"
+  ],
+  "panels": [
+    "tree",
+    "map",
+    "entropy",
+    "frequencies"
+  ],
+  "filters": [
+    "recency",
+    "region",
+    "country",
+    "division",
+    "purpose_of_sequencing",
+    "pango_lineage",
+    "Nextstrain_clade",
+    "GISAID_clade",
+    "originating_lab",
+    "submitting_lab",
+    "Longitudinal_Patient"
+  ],
+  "data_provenance": [
+    {
+      "name": "GISAID"
+    }
+  ]
+}

--- a/configs/auspice_config_gisaid-ecowas.json
+++ b/configs/auspice_config_gisaid-ecowas.json
@@ -1,0 +1,142 @@
+{
+  "title": "SARS-CoV-2 Viral Genomes",
+  "maintainers": [
+    {"name": "Broad Institute Viral Genomics", "url": "https://www.broadinstitute.org/"}
+  ],
+  "colorings": [
+    {
+      "key": "location",
+      "title": "Location",
+      "type": "categorical"
+    },
+    {
+      "key": "division",
+      "title": "Admin Division",
+      "type": "categorical"
+    },
+    {
+      "key": "country",
+      "title": "Country",
+      "type": "categorical"
+    },
+    {
+      "key": "region",
+      "title": "Region",
+      "type": "categorical"
+    },
+    {
+      "key": "host",
+      "title": "Host",
+      "type": "categorical"
+    },
+    {
+      "key": "age",
+      "title": "Age",
+      "type": "continuous"
+    },
+    {
+      "key": "sex",
+      "title": "Sex",
+      "type": "categorical"
+    },
+    {
+      "key": "author",
+      "title": "Authors",
+      "type": "categorical"
+    },
+    {
+      "key": "originating_lab",
+      "title": "Originating Lab",
+      "type": "categorical"
+    },
+    {
+      "key": "submitting_lab",
+      "title": "Submitting Lab",
+      "type": "categorical"
+    },
+    {
+      "key": "recency",
+      "title": "Submission Date",
+      "type": "categorical"
+    },
+    {
+      "key": "gisaid_epi_isl",
+      "type": "categorical"
+    },
+    {
+      "key": "genbank_accession",
+      "type": "categorical"
+    },
+    {
+      "key": "country_exposure",
+      "title": "Country of exposure",
+      "type": "categorical"
+    },
+    {
+      "key": "division_exposure",
+      "title": "Division of exposure",
+      "type": "categorical"
+    },
+    {
+      "key": "region_exposure",
+      "title": "Region of exposure",
+      "type": "categorical"
+    },
+    {
+      "key": "pango_lineage",
+      "title": "Pangolin lineage",
+      "type": "categorical"
+    },
+    {
+      "key": "Nextstrain_clade",
+      "title": "Nextstrain Clade",
+      "type": "categorical"
+    },
+    {
+      "key": "GISAID_clade",
+      "title": "GISAID Clade",
+      "type": "categorical"
+    },
+    {
+      "key": "purpose_of_sequencing",
+      "title": "Purpose of Sequencing",
+      "type": "categorical"
+    }
+  ],
+  "display_defaults": {
+    "color_by": "country",
+    "distance_measure": "num_date",
+    "geo_resolution": "division",
+    "map_triplicate": true,
+    "branch_label": "clade"
+  },
+  "geo_resolutions": [
+    "region",
+    "country",
+    "division",
+    "location"
+  ],
+  "panels": [
+    "tree",
+    "map",
+    "entropy",
+    "frequencies"
+  ],
+  "filters": [
+    "recency",
+    "region",
+    "country",
+    "division",
+    "purpose_of_sequencing",
+    "pango_lineage",
+    "Nextstrain_clade",
+    "GISAID_clade",
+    "originating_lab",
+    "submitting_lab"
+  ],
+  "data_provenance": [
+    {
+      "name": "GISAID"
+    }
+  ]
+}

--- a/configs/auspice_config_gisaid-generic-grouping.json
+++ b/configs/auspice_config_gisaid-generic-grouping.json
@@ -1,0 +1,140 @@
+{
+  "maintainers": [
+    {"name": "Broad Institute - Viral Genomics", "url": "https://www.broadinstitute.org/viral-genomics"}
+  ],
+  "colorings": [
+    {
+      "key": "location",
+      "title": "Location",
+      "type": "categorical"
+    },
+    {
+      "key": "division",
+      "title": "Admin Division",
+      "type": "categorical"
+    },
+    {
+      "key": "country",
+      "title": "Country",
+      "type": "categorical"
+    },
+    {
+      "key": "region",
+      "title": "Region",
+      "type": "categorical"
+    },
+    {
+      "key": "host",
+      "title": "Host",
+      "type": "categorical"
+    },
+    {
+      "key": "age",
+      "title": "Age",
+      "type": "continuous"
+    },
+    {
+      "key": "sex",
+      "title": "Sex",
+      "type": "categorical"
+    },
+    {
+      "key": "author",
+      "title": "Authors",
+      "type": "categorical"
+    },
+    {
+      "key": "originating_lab",
+      "title": "Originating Lab",
+      "type": "categorical"
+    },
+    {
+      "key": "submitting_lab",
+      "title": "Submitting Lab",
+      "type": "categorical"
+    },
+    {
+      "key": "recency",
+      "title": "Submission Date",
+      "type": "categorical"
+    },
+    {
+      "key": "gisaid_epi_isl",
+      "type": "categorical"
+    },
+    {
+      "key": "genbank_accession",
+      "type": "categorical"
+    },
+    {
+      "key": "country_exposure",
+      "title": "Country of exposure",
+      "type": "categorical"
+    },
+    {
+      "key": "division_exposure",
+      "title": "Division of exposure",
+      "type": "categorical"
+    },
+    {
+      "key": "region_exposure",
+      "title": "Region of exposure",
+      "type": "categorical"
+    },
+    {
+      "key": "pango_lineage",
+      "title": "Pangolin lineage",
+      "type": "categorical"
+    },
+    {
+      "key": "GISAID_clade",
+      "title": "GISAID Clade",
+      "type": "categorical"
+    },
+    {
+      "key": "grouping",
+      "title": "Grouping",
+      "type": "categorical"
+    },
+    {
+      "key": "cluster",
+      "title": "Cluster",
+      "type": "categorical"
+    }
+  ],
+  "geo_resolutions": [
+    "region",
+    "country",
+    "division",
+    "location"
+  ],
+  "display_defaults": {
+    "color_by": "division",
+    "distance_measure": "num_date",
+    "geo_resolution": "division",
+    "map_triplicate": true,
+    "branch_label": "clade"
+  },
+  "filters": [
+    "recency",
+    "location",
+    "division",
+    "country",
+    "region",
+    "host",
+    "author",
+    "grouping",
+    "cluster"
+  ],
+  "panels": [
+    "tree",
+    "map",
+    "entropy",
+    "frequencies"
+  ],
+  "data_provenance": [
+    {
+      "name": "GISAID"
+    }
+  ]
+}

--- a/configs/auspice_config_gisaid-generic.json
+++ b/configs/auspice_config_gisaid-generic.json
@@ -1,0 +1,125 @@
+{
+  "colorings": [
+    {
+      "key": "location",
+      "title": "Location",
+      "type": "categorical"
+    },
+    {
+      "key": "division",
+      "title": "Admin Division",
+      "type": "categorical"
+    },
+    {
+      "key": "country",
+      "title": "Country",
+      "type": "categorical"
+    },
+    {
+      "key": "region",
+      "title": "Region",
+      "type": "categorical"
+    },
+    {
+      "key": "host",
+      "title": "Host",
+      "type": "categorical"
+    },
+    {
+      "key": "age",
+      "title": "Age",
+      "type": "continuous"
+    },
+    {
+      "key": "sex",
+      "title": "Sex",
+      "type": "categorical"
+    },
+    {
+      "key": "author",
+      "title": "Authors",
+      "type": "categorical"
+    },
+    {
+      "key": "originating_lab",
+      "title": "Originating Lab",
+      "type": "categorical"
+    },
+    {
+      "key": "submitting_lab",
+      "title": "Submitting Lab",
+      "type": "categorical"
+    },
+    {
+      "key": "recency",
+      "title": "Submission Date",
+      "type": "categorical"
+    },
+    {
+      "key": "gisaid_epi_isl",
+      "type": "categorical"
+    },
+    {
+      "key": "genbank_accession",
+      "type": "categorical"
+    },
+    {
+      "key": "country_exposure",
+      "title": "Country of exposure",
+      "type": "categorical"
+    },
+    {
+      "key": "division_exposure",
+      "title": "Division of exposure",
+      "type": "categorical"
+    },
+    {
+      "key": "region_exposure",
+      "title": "Region of exposure",
+      "type": "categorical"
+    },
+    {
+      "key": "pango_lineage",
+      "title": "Pangolin lineage",
+      "type": "categorical"
+    },
+    {
+      "key": "GISAID_clade",
+      "title": "GISAID Clade",
+      "type": "categorical"
+    }
+  ],
+  "geo_resolutions": [
+    "location",
+    "division",
+    "country",
+    "region"
+  ],
+  "display_defaults": {
+    "color_by": "division",
+    "distance_measure": "num_date",
+    "geo_resolution": "division",
+    "map_triplicate": true,
+    "branch_label": "none"
+  },
+  "filters": [
+    "recency",
+    "location",
+    "division",
+    "country",
+    "region",
+    "host",
+    "author"
+  ],
+  "panels": [
+    "tree",
+    "map",
+    "entropy",
+    "frequencies"
+  ],
+  "data_provenance": [
+    {
+      "name": "GISAID"
+    }
+  ]
+}

--- a/configs/auspice_config_gisaid-mountainwestusa.json
+++ b/configs/auspice_config_gisaid-mountainwestusa.json
@@ -1,0 +1,125 @@
+{
+  "title": "SARS-CoV-2 Genomic Epidemiology: Mountain West region of the United States",
+  "maintainers": [
+    {"name": "Broad Institute - Viral Genomics", "url": "https://www.broadinstitute.org/viral-genomics"}
+  ],
+  "colorings": [
+    {
+      "key": "location",
+      "title": "County",
+      "type": "categorical"
+    },
+    {
+      "key": "division",
+      "title": "State",
+      "type": "categorical"
+    },
+    {
+      "key": "country",
+      "title": "Country",
+      "type": "categorical"
+    },
+    {
+      "key": "region",
+      "title": "Region",
+      "type": "categorical"
+    },
+    {
+      "key": "host",
+      "title": "Host",
+      "type": "categorical"
+    },
+    {
+      "key": "recency",
+      "title": "Submission Date",
+      "type": "categorical"
+    },
+    {
+      "key": "country_exposure",
+      "title": "Country of exposure",
+      "type": "categorical"
+    },
+    {
+      "key": "division_exposure",
+      "title": "Division of exposure",
+      "type": "categorical"
+    },
+    {
+      "key": "region_exposure",
+      "title": "Region of exposure",
+      "type": "categorical"
+    },
+    {
+      "key": "pango_lineage",
+      "title": "Pangolin lineage",
+      "type": "categorical"
+    },
+    {
+      "key": "Nextstrain_clade",
+      "title": "Nextstrain Clade",
+      "type": "categorical"
+    },
+    {
+      "key": "GISAID_clade",
+      "title": "GISAID Clade",
+      "type": "categorical"
+    },
+    {
+      "key": "purpose_of_sequencing",
+      "title": "Purpose of Sequencing",
+      "type": "categorical"
+    },
+    {
+      "key": "geoloc_mountainwestusa",
+      "title": "Geoloc: MW USA",
+      "type": "categorical"
+    },
+    {
+      "key": "grouping",
+      "title": "Grouping",
+      "type": "categorical"
+    },
+    {
+      "key": "cluster",
+      "title": "Cluster",
+      "type": "categorical"
+    }
+  ],
+  "display_defaults": {
+    "color_by": "division",
+    "distance_measure": "num_date",
+    "geo_resolution": "division",
+    "map_triplicate": true,
+    "branch_label": "clade"
+  },
+  "geo_resolutions": [
+    "region",
+    "country",
+    "division",
+    "location"
+  ],
+  "panels": [
+    "tree",
+    "map",
+    "entropy",
+    "frequencies"
+  ],
+  "filters": [
+    "recency",
+    "geoloc_mountainwestusa",
+    "region",
+    "country",
+    "division",
+    "purpose_of_sequencing",
+    "pango_lineage",
+    "Nextstrain_clade",
+    "GISAID_clade",
+    "grouping",
+    "cluster"
+  ],
+  "data_provenance": [
+    {
+      "name": "GISAID"
+    }
+  ]
+}

--- a/configs/auspice_config_gisaid-neusa.json
+++ b/configs/auspice_config_gisaid-neusa.json
@@ -1,0 +1,127 @@
+{
+  "title": "SARS-CoV-2 Genomic Epidemiology: Northeastern United States",
+  "maintainers": [
+    {"name": "Yale School of Public Health - Grubaugh Lab", "url": "https://grubaughlab.com/"},
+    {"name": "Jackson Laboratory - Tewhey Lab", "url": "http://www.tewheylab.org/"},
+    {"name": "Broad Institute - Viral Genomics", "url": "https://www.broadinstitute.org/viral-genomics"}
+  ],
+  "colorings": [
+    {
+      "key": "location",
+      "title": "County",
+      "type": "categorical"
+    },
+    {
+      "key": "division",
+      "title": "State",
+      "type": "categorical"
+    },
+    {
+      "key": "country",
+      "title": "Country",
+      "type": "categorical"
+    },
+    {
+      "key": "region",
+      "title": "Region",
+      "type": "categorical"
+    },
+    {
+      "key": "host",
+      "title": "Host",
+      "type": "categorical"
+    },
+    {
+      "key": "recency",
+      "title": "Submission Date",
+      "type": "categorical"
+    },
+    {
+      "key": "country_exposure",
+      "title": "Country of exposure",
+      "type": "categorical"
+    },
+    {
+      "key": "division_exposure",
+      "title": "Division of exposure",
+      "type": "categorical"
+    },
+    {
+      "key": "region_exposure",
+      "title": "Region of exposure",
+      "type": "categorical"
+    },
+    {
+      "key": "pango_lineage",
+      "title": "Pangolin lineage",
+      "type": "categorical"
+    },
+    {
+      "key": "Nextstrain_clade",
+      "title": "Nextstrain Clade",
+      "type": "categorical"
+    },
+    {
+      "key": "GISAID_clade",
+      "title": "GISAID Clade",
+      "type": "categorical"
+    },
+    {
+      "key": "purpose_of_sequencing",
+      "title": "Purpose of Sequencing",
+      "type": "categorical"
+    },
+    {
+      "key": "geoloc_neusa",
+      "title": "Geoloc: NE USA",
+      "type": "categorical"
+    },
+    {
+      "key": "Northeast_USA_originating_lab",
+      "title": "NE USA Originating Lab",
+      "type": "categorical"
+    },
+     {
+      "key": "Northeast_USA_submitting_lab",
+      "title": "NE USA Submitting Lab",
+      "type": "categorical"
+    }
+  ],
+  "display_defaults": {
+    "color_by": "division",
+    "distance_measure": "num_date",
+    "geo_resolution": "division",
+    "map_triplicate": true,
+    "branch_label": "clade"
+  },
+  "geo_resolutions": [
+    "region",
+    "country",
+    "division",
+    "location"
+  ],
+  "panels": [
+    "tree",
+    "map",
+    "entropy",
+    "frequencies"
+  ],
+  "filters": [
+    "recency",
+    "geoloc_neusa",
+    "region",
+    "country",
+    "division",
+    "purpose_of_sequencing",
+    "pango_lineage",
+    "Nextstrain_clade",
+    "GISAID_clade",
+    "Northeast_USA_originating_lab",
+    "Northeast_USA_submitting_lab"
+  ],
+  "data_provenance": [
+    {
+      "name": "GISAID"
+    }
+  ]
+}


### PR DESCRIPTION
add copies of auspice export config json files with 'data_provenance' set to name=GISAID to enable display of GISAID button for attribution, as well as switch of metadata download to acknowledgement download. 

See:
* https://github.com/nextstrain/augur/pull/705
* https://github.com/nextstrain/auspice/blob/master/CHANGELOG.md#version-2280---20210705