### PR TITLE
add new build "us-mountain-west-study-grouping-weighted"

### DIFF
--- a/builds/broad-usa-builds.yaml
+++ b/builds/broad-usa-builds.yaml
@@ -134,6 +134,11 @@ builds:
     cluster_query: "longest_submittable_genome_from_patient=='Yes' and (purpose_of_sequencing=='Cluster/Outbreak investigation' or purpose_of_sequencing=='Targeted surveillance (non-random sampling)' or purpose_of_sequencing=='SNF B') and division=='Massachusetts' and date >= '2021-07-01' and date < '2021-09-01'"
     state_query: "division=='Massachusetts'"
 
+  us-mountain-west-study-grouping-weighted:
+    subsampling_scheme: multistate-grouping-weighted
+    country: USA
+    state_query: "division=='Colorado' or division=='Utah' or division=='Arizona' or division=='Wyoming' or division=='New Mexico' or division=='Idaho' or division=='Montana' or division=='Nevada' or originating_lab=='CDPHE' or originating_lab=='Colorado Department of Public Health and Environment'"
+
 subsampling:
 
   state:

--- a/builds/broad-usa-builds.yaml
+++ b/builds/broad-usa-builds.yaml
@@ -257,7 +257,7 @@ subsampling:
   multistate-grouping-weighted:
     focal:
       group_by: "year month"
-      max_sequences: 2500
+      max_sequences: 2000
       query: --query "(country=='{country}' and ({state_query}))"
 
     focal-grouping:
@@ -274,10 +274,19 @@ subsampling:
         type: proximity
         focus: focal-grouping
 
+    # Samples that are genetically related to the focal samples
+    state-context:
+      group_by: "year month"
+      max_sequences: 1000
+      query: --query "(({state_query}) and not country=='{country}' and (grouping == '?' or grouping == '' or grouping == 'UNKNOWN' or grouping.str.len() == 0) )"
+      priorities:
+        type: proximity
+        focus: focal-grouping
+
     # Contextual samples from the rest of the world
     global-context:
       group_by: "region year month"
-      max_sequences: 400
+      max_sequences: 500
       exclude: --exclude-where "country='{country}'"
       priorities:
         type: proximity


### PR DESCRIPTION
add new build "us-mountain-west-study-grouping-weighted", that adds a condition to match CO sequences based on their division label OR the originating_lab being equal to 'CDPHE' or 'Colorado Department of Public Health and Environment' (since many CDPHE sequences lack a CO label for division)